### PR TITLE
Change tuple interface

### DIFF
--- a/komfydb/common/tuple.cc
+++ b/komfydb/common/tuple.cc
@@ -5,22 +5,22 @@
 
 namespace komfydb::common {
 
-Tuple::Tuple(const TupleDesc& td) : td(td) {
-  fields.resize(td.Length());
+Tuple::Tuple(const TupleDesc* td) : td(td) {
+  fields.resize(td->Length());
 }
 
-TupleDesc Tuple::GetTupleDesc() {
-  return TupleDesc(td);
+const TupleDesc* Tuple::GetTupleDesc() {
+  return td;
 }
 
-absl::StatusOr<std::shared_ptr<Field>> Tuple::GetField(int i) {
+absl::StatusOr<Field*> Tuple::GetField(int i) {
   if (fields.size() <= i || i < 0) {
     return absl::InvalidArgumentError("Index out of range");
   }
   return fields[i];
 }
 
-absl::Status Tuple::SetField(int i, std::shared_ptr<Field> f) {
+absl::Status Tuple::SetField(int i, Field* f) {
   if (fields.size() <= i || i < 0) {
     return absl::InvalidArgumentError("Index out of range");
   }

--- a/komfydb/common/tuple.h
+++ b/komfydb/common/tuple.h
@@ -16,22 +16,18 @@ namespace komfydb::common {
 // representing a Tuple in memory.
 class Tuple {
  protected:
-  TupleDesc td;
+  const TupleDesc *td;
 
-  std::vector<std::shared_ptr<Field>> fields;
+  std::vector<Field*> fields;
 
  public:
-  Tuple(const TupleDesc& td);
+  Tuple(const TupleDesc* td);
 
-  TupleDesc GetTupleDesc();
+  const TupleDesc* GetTupleDesc();
 
-  // TODO it would be much nicer to have absl::StatusOr<Field> instead, but
-  // unfortunately it cannot be done as StatusOr tries to instatiate
-  // the object of the Field type (which is an abstract class).
-  // Try changing Field class so it can work (and don't break the abstraction).
-  absl::StatusOr<std::shared_ptr<Field>> GetField(int i);
+  absl::StatusOr<Field*> GetField(int i);
 
-  absl::Status SetField(int i, std::shared_ptr<Field> f);
+  absl::Status SetField(int i, Field* f);
 
   operator std::string() const;
 

--- a/komfydb/common/tuple_test.cc
+++ b/komfydb/common/tuple_test.cc
@@ -16,12 +16,12 @@ TEST(Tuple, StringConversion) {
   std::vector<std::string> nv{"f1", "f2"};
 
   TupleDesc td(tv, nv);
-  Tuple tuple(td);
+  Tuple tuple(&td);
 
-  std::shared_ptr<IntField> f(new IntField(1));
-  std::cout << tuple.SetField(0, f).ok() << "\n";
-  std::cout << tuple.SetField(0, f).message() << "\n";
-  EXPECT_TRUE(tuple.SetField(0, f).ok());
+  IntField f(1);
+  std::cout << tuple.SetField(0, &f).ok() << "\n";
+  std::cout << tuple.SetField(0, &f).message() << "\n";
+  EXPECT_TRUE(tuple.SetField(0, &f).ok());
 
   auto f1 = tuple.GetField(0);
   ASSERT_TRUE(f1.ok());


### PR DESCRIPTION
Got rid of shared_ptr which adds additional overhead. Now it seems that there is a place for optimization in the future, but for now vector<Field*> should be OK. Just need to take extra caution.