### PR TITLE
Changed OpIterator interface, added factory method to SeqScan.

### DIFF
--- a/komfydb/execution/BUILD
+++ b/komfydb/execution/BUILD
@@ -17,6 +17,7 @@ cc_library(
   deps = [
     ":op",
     "//komfydb/storage:storage",
+    "//komfydb/utils:utility",
     "@com_google_absl//absl/status",
   ],
   visibility = ["//visibility:public"],

--- a/komfydb/execution/op_iterator.h
+++ b/komfydb/execution/op_iterator.h
@@ -28,7 +28,7 @@ class OpIterator {
 
   virtual absl::StatusOr<Record> Next() = 0;
 
-  virtual absl::StatusOr<TupleDesc*> GetTupleDesc() = 0;
+  virtual TupleDesc* GetTupleDesc() = 0;
 };
 
 };  // namespace komfydb::execution

--- a/komfydb/execution/seq_scan.h
+++ b/komfydb/execution/seq_scan.h
@@ -26,10 +26,12 @@ namespace komfydb::execution {
 
 class SeqScan : public OpIterator {
  public:
-  SeqScan(TableIterator iterator, TransactionId tid,
-          absl::string_view table_alias, int table_id);
+  static absl::StatusOr<std::unique_ptr<SeqScan>> Create(
+      std::unique_ptr<TableIterator> iterator, TransactionId tid,
+      absl::string_view table_alias, int table_id);
 
-  SeqScan(TableIterator iterator, TransactionId tid, int table_id);
+  static absl::StatusOr<std::unique_ptr<SeqScan>> Create(
+      std::unique_ptr<TableIterator> iterator, TransactionId tid, int table_id);
 
   absl::Status Open() override;
 
@@ -41,10 +43,17 @@ class SeqScan : public OpIterator {
 
   absl::StatusOr<Record> Next() override;
 
-  absl::StatusOr<TupleDesc*> GetTupleDesc() override;
+  TupleDesc* GetTupleDesc() override;
 
  private:
-  TableIterator iterator;
+  SeqScan(std::unique_ptr<TableIterator> iterator, TransactionId tid,
+          TupleDesc td, absl::string_view table_alias, int table_id);
+
+  SeqScan(std::unique_ptr<TableIterator> iterator, TransactionId tid,
+          TupleDesc td, int table_id);
+
+  std::unique_ptr<TableIterator> iterator;
+  TupleDesc td;
   TransactionId tid;
   std::string table_alias;
   int table_id;


### PR DESCRIPTION
OpIterator's GetTupleDesc should never return an error. That's why SeqScan now needs a factory method which fetches the TupleDescriptor from TableIterator and stores it.