### PR TITLE
Logical plan parsing

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,7 +1,7 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "make")
 
 make(
-  name = "sql_parser",
+  name = "hsql",
   lib_source = "@sql_parser//:all_srcs",
   args = ["static=yes INSTALL=$$INSTALLDIR$$"],
   out_static_libs = ["libsqlparser.a"],

--- a/komfydb/BUILD
+++ b/komfydb/BUILD
@@ -48,6 +48,55 @@ cc_test(
   ],
 )
 
+cc_library(
+  name = "parser",
+  srcs = ["parser.cc"],
+  hdrs = ["parser.h"],
+  deps = [
+    "//komfydb/execution/logical_plan:logical_plan",
+    "//:hsql",
+    "@com_google_absl//absl/status:statusor",
+    "@com_github_google_glog//:glog",
+  ],
+)
+
+cc_test(
+  name = "parser_test",
+  srcs = ["parser_test.cc",],
+  data = [
+    "testdata/database_catalog_test.txt",
+    "testdata/first_table.dat",
+    "testdata/second_table.dat",
+  ],
+  deps = [
+    ":parser",
+    ":database",
+    "@com_google_googletest//:gtest_main",
+  ],
+)
+
+cc_binary(
+  name = "parser_repl",
+  srcs = ["parser_repl.cc",],
+  data = [
+    "testdata/database_catalog_test.txt",
+    "testdata/first_table.dat",
+    "testdata/second_table.dat",
+  ],
+  deps = [
+    ":parser",
+    "//komfydb/execution/logical_plan",
+    "//komfydb:database",
+    "//komfydb/storage:storage",
+    "//komfydb/common:common",
+    "//komfydb/transaction:transaction",
+    "//komfydb/execution:execution",
+    "@com_github_google_glog//:glog",
+    "//:hsql",
+  ],
+  linkopts = ["-lreadline",],
+)
+
 cc_binary(
   name = "komfydb",
   srcs = ["komfydb.cc"],
@@ -70,7 +119,7 @@ cc_binary(
   name = "sql_parser_test",
   srcs = ["sql_parser_test.cc",],
   deps = [
-    "//:sql_parser",
+    "//:hsql",
   ],
   linkopts = ["-lreadline",],
 )

--- a/komfydb/common/BUILD
+++ b/komfydb/common/BUILD
@@ -1,4 +1,10 @@
 cc_library(
+  name = "column_ref",
+  hdrs = ["column_ref.h"],
+  visibility = ["//visibility:public"],
+)
+
+cc_library(
   name = "fields",
   srcs = [
     "string_field.cc",
@@ -68,6 +74,7 @@ cc_library(
     "debug.cc",
   ],
   deps = [
+    ":column_ref",
     ":fields",
     ":tuple",
     "//komfydb/utils:utility",

--- a/komfydb/common/column_ref.h
+++ b/komfydb/common/column_ref.h
@@ -1,0 +1,30 @@
+#ifndef __COLUMN_REF_H__
+#define __COLUMN_REF_H__
+
+#include <string>
+
+namespace komfydb::common {
+
+struct ColumnRef {
+  // Table alias.
+  std::string table;
+  // Column name.
+  std::string column;
+
+  ColumnRef() : table(""), column("") {}
+
+  ColumnRef(std::string_view table, std::string_view column)
+      : table(table), column(column) {}
+
+  bool IsValid() { return table != "" && column != ""; }
+
+  bool IsStar() { return table == "null" && column == "*"; }
+
+  operator std::string() const { return table + "." + column; }
+};
+
+const ColumnRef COLUMN_REF_STAR("null", "*");
+
+};  // namespace komfydb::common
+
+#endif  // __COLUMN_REF_H__

--- a/komfydb/common/tuple_desc.cc
+++ b/komfydb/common/tuple_desc.cc
@@ -71,7 +71,7 @@ absl::StatusOr<int> TupleDesc::IndexForFieldName(
     }
   }
 
-  return absl::InvalidArgumentError("No field with given name");
+  return absl::InvalidArgumentError(absl::StrCat("No field with name ", name));
 }
 
 int TupleDesc::GetSize() const {

--- a/komfydb/execution/BUILD
+++ b/komfydb/execution/BUILD
@@ -3,6 +3,10 @@ cc_library(
   srcs = ["op.cc"],
   hdrs = ["op.h"],
   visibility = ["//visibility:public"],
+  deps = [
+    "@com_google_absl//absl/status:statusor",
+    "@com_google_absl//absl/container:flat_hash_map",
+  ],
 )
 
 cc_library(
@@ -11,6 +15,7 @@ cc_library(
     "op_iterator.h",
     "seq_scan.h",
     "order_by.h",
+    "aggregate.h",
   ],
   srcs = [
     "seq_scan.cc",

--- a/komfydb/execution/aggregate.h
+++ b/komfydb/execution/aggregate.h
@@ -1,0 +1,59 @@
+#ifndef __AGGREGATE_H__
+#define __AGGREGATE_H__
+
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+
+namespace komfydb::execution {
+
+class Aggregate {
+ public:
+  enum AggregateType {
+    NONE,
+    MAX,
+    MIN,
+    SUM,
+    AVG,
+    COUNT,
+  };
+
+  static absl::StatusOr<AggregateType> GetAggregateType(std::string_view fun) {
+    absl::flat_hash_map<std::string, AggregateType> str_to_agg = {
+        {"max", MAX}, {"min", MIN},     {"sum", SUM},
+        {"avg", AVG}, {"count", COUNT},
+    };
+    std::string lower_fun = std::string(fun);
+    for (char& c : lower_fun) {
+      c = std::tolower(c);
+    }
+    auto it = str_to_agg.find(lower_fun);
+    if (it == str_to_agg.end()) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Unknown aggregate function ", fun));
+    }
+    return it->second;
+  }
+
+  static std::string AggregateTypeToString(AggregateType type) {
+    switch (type) {
+      case NONE:
+        return "none";
+      case MAX:
+        return "max";
+      case MIN:
+        return "min";
+      case SUM:
+        return "sum";
+      case AVG:
+        return "avg";
+      case COUNT:
+        return "count";
+    }
+  }
+};
+
+};  // namespace komfydb::execution
+
+#endif  // __AGGREGATE_H__

--- a/komfydb/execution/logical_plan/BUILD
+++ b/komfydb/execution/logical_plan/BUILD
@@ -1,0 +1,22 @@
+cc_library(
+  name = "logical_plan",
+  srcs = [
+    "logical_plan.cc",
+  ],
+  hdrs = [
+    "filter_node.h",
+    "join_node.h",
+    "logical_plan.h",
+    "scan_node.h",
+    "select_node.h",
+  ],
+  deps = [
+    "//komfydb/storage",
+    "//komfydb/common",
+    "//komfydb/execution",
+    "//:hsql",
+    "@com_google_absl//absl/container:flat_hash_map",
+    "@com_google_absl//absl/status:statusor",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/komfydb/execution/logical_plan/filter_node.h
+++ b/komfydb/execution/logical_plan/filter_node.h
@@ -1,0 +1,56 @@
+#ifndef __FILTER_NODE_H__
+#define __FILTER_NODE_H__
+
+#include "komfydb/common/column_ref.h"
+#include "komfydb/common/field.h"
+#include "komfydb/execution/op.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+using komfydb::common::Field;
+
+};  // namespace
+
+namespace komfydb::execution::logical_plan {
+
+class FilterNode {
+ public:
+  enum FilterType {
+    TWO_COLUMNS,
+    COLUMN_CONSTANT,
+  };
+
+  ColumnRef lcol;
+  ColumnRef rcol;
+  std::unique_ptr<Field> constant;
+  Op op;
+  FilterType type;
+
+  FilterNode(ColumnRef lcol, Op op, ColumnRef rcol)
+      : lcol(lcol), rcol(rcol), op(op), type(TWO_COLUMNS) {}
+
+  FilterNode(ColumnRef lcol, Op op, std::unique_ptr<Field> constant)
+      : lcol(lcol),
+        rcol(ColumnRef("", "")),
+        constant(std::move(constant)),
+        op(op),
+        type(COLUMN_CONSTANT) {}
+
+  operator std::string() const {
+    switch (type) {
+      case TWO_COLUMNS:
+        return static_cast<std::string>(lcol) + " " +
+               static_cast<std::string>(op) + " " +
+               static_cast<std::string>(rcol);
+      case COLUMN_CONSTANT:
+        return static_cast<std::string>(lcol) + " " +
+               static_cast<std::string>(op) + " " +
+               static_cast<std::string>(*constant);
+    }
+  }
+};
+
+};  // namespace komfydb::execution::logical_plan
+
+#endif  // __FILTER_NODE_H__

--- a/komfydb/execution/logical_plan/join_node.h
+++ b/komfydb/execution/logical_plan/join_node.h
@@ -1,0 +1,39 @@
+#ifndef __JOIN_NODE_H__
+#define __JOIN_NODE_H__
+
+#include "komfydb/common/column_ref.h"
+#include "komfydb/execution/op.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+
+};
+
+namespace komfydb::execution::logical_plan {
+
+class LogicalPlan;
+
+class JoinNode {
+ public:
+  enum Type {
+    COL_COL,
+    COL_SUB,
+  };
+
+  ColumnRef lref;
+  ColumnRef rref;
+  std::unique_ptr<LogicalPlan> subplan;
+  Op op;
+  Type type;
+
+  JoinNode(ColumnRef lref, Op op, ColumnRef rref)
+      : lref(lref), rref(rref), op(op), type(COL_COL) {}
+
+  JoinNode(ColumnRef lref, Op op, std::unique_ptr<LogicalPlan> subplan)
+      : lref(lref), subplan(std::move(subplan)), op(op), type(COL_SUB) {}
+};
+
+};  // namespace komfydb::execution::logical_plan
+
+#endif  // __JOIN_NODE_H__

--- a/komfydb/execution/logical_plan/logical_plan.cc
+++ b/komfydb/execution/logical_plan/logical_plan.cc
@@ -1,0 +1,185 @@
+#include "komfydb/execution/logical_plan/logical_plan.h"
+
+#include <iostream>
+#include <memory>
+#include <string_view>
+
+#include "komfydb/common/tuple_desc.h"
+#include "komfydb/utils/status_macros.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+using komfydb::common::TupleDesc;
+using komfydb::common::Type;
+
+};  // namespace
+
+namespace komfydb::execution::logical_plan {
+
+absl::Status LogicalPlan::CheckColumnRef(ColumnRef ref) {
+  if (ref.IsStar())
+    return absl::OkStatus();
+  auto it = alias_to_id.find(ref.table);
+  if (it == alias_to_id.end()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unknown alias ", ref.table));
+  }
+  ASSIGN_OR_RETURN(TupleDesc * td, catalog->GetTupleDesc(it->second));
+  return td->IndexForFieldName(ref.column).status();
+}
+
+absl::Status LogicalPlan::AddScan(int table_id, std::string_view alias) {
+  if (alias_to_id.contains(alias)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Another use of alias ", alias));
+  }
+  scans.push_back(ScanNode(table_id, alias));
+  alias_to_id[alias] = table_id;
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddJoin(ColumnRef lref, Op op, ColumnRef rref) {
+  RETURN_IF_ERROR(CheckColumnRef(lref));
+  RETURN_IF_ERROR(CheckColumnRef(rref));
+  joins.push_back(JoinNode(lref, op, rref));
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddSubqueryJoin(ColumnRef ref, Op op,
+                                          LogicalPlan subplan) {
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  std::unique_ptr<LogicalPlan> subplan_ptr =
+      std::make_unique<LogicalPlan>(std::move(subplan));
+  joins.push_back(JoinNode(ref, op, std::move(subplan_ptr)));
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddFilterColCol(ColumnRef lref, Op op,
+                                          ColumnRef rref) {
+  RETURN_IF_ERROR(CheckColumnRef(lref));
+  RETURN_IF_ERROR(CheckColumnRef(rref));
+  filters.push_back(FilterNode(lref, op, rref));
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddFilterColConst(
+    ColumnRef ref, Op op, std::unique_ptr<Field> const_field) {
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  filters.push_back(FilterNode(ref, op, std::move(const_field)));
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddGroupBy(ColumnRef ref) {
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  group_by_column = ref;
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddAggregate(std::string_view agg_fun,
+                                       ColumnRef ref) {
+  ASSIGN_OR_RETURN(agg_type, Aggregate::GetAggregateType(agg_fun));
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  agg_column = ref;
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddSelect(ColumnRef ref) {
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  selects.push_back(SelectNode(ref));
+  return absl::OkStatus();
+}
+
+absl::Status LogicalPlan::AddOrderBy(ColumnRef ref, OrderBy::Order asc) {
+  RETURN_IF_ERROR(CheckColumnRef(ref));
+  order_by_column = ref;
+  order = asc;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<ColumnRef> LogicalPlan::GetColumnRef(std::string_view table,
+                                                    std::string_view column) {
+  if (table != "") {
+    return ColumnRef(table, column);
+  }
+
+  for (auto& it : alias_to_id) {
+    ASSIGN_OR_RETURN(TupleDesc * td, catalog->GetTupleDesc(it.second));
+    if (td->IndexForFieldName(column).ok()) {
+      if (table != "") {
+        return absl::InvalidArgumentError(
+            absl::StrCat("Column ", column, " without table name is ambigous"));
+      }
+      table = it.first;
+    }
+  }
+
+  if (table == "") {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Column ", column, " does not appear in any table"));
+  }
+  return ColumnRef(table, column);
+}
+
+absl::StatusOr<common::ColumnRef> LogicalPlan::GetColumnRef(char* table,
+                                                            char* column) {
+  return GetColumnRef(table ? table : "", column ? column : "");
+}
+
+absl::StatusOr<common::Type> LogicalPlan::GetColumnType(ColumnRef ref) {
+  auto it = alias_to_id.find(ref.table);
+  if (it == alias_to_id.end()) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Invalid column reference: no table with alias ", ref.table));
+  }
+  ASSIGN_OR_RETURN(TupleDesc * td, catalog->GetTupleDesc(it->second));
+  ASSIGN_OR_RETURN(int column_idx, td->IndexForFieldName(ref.column));
+  ASSIGN_OR_RETURN(Type t, td->GetFieldType(column_idx));
+  return t;
+}
+
+void LogicalPlan::Dump() {
+  std::cout << "alias_to_id: (" << alias_to_id.size() << ")\n";
+
+  for (auto& it : alias_to_id) {
+    std::cout << it.first << " -> " << it.second << "\n";
+  }
+
+  std::cout << "Scan nodes: (" << scans.size() << ")\n";
+  for (auto& it : scans) {
+    std::cout << static_cast<std::string>(it) << "\n";
+  }
+
+  std::cout << "Select nodes: (" << selects.size() << ")\n";
+  for (auto& it : selects) {
+    std::cout << static_cast<std::string>(it) << "\n";
+  }
+
+  std::cout << "Filter nodes: (" << filters.size() << ")\n";
+  for (auto& it : filters) {
+    std::cout << static_cast<std::string>(it) << "\n";
+  }
+
+  std::cout << "Join nodes: (" << joins.size() << ")\n";
+  for (auto& it : joins) {
+    std::cout << static_cast<std::string>(it.lref) + " " +
+                     static_cast<std::string>(it.op)
+              << " ";
+    if (it.type == JoinNode::COL_COL) {
+      std::cout << static_cast<std::string>(it.rref) << "\n";
+    } else {
+      std::cout << "Subplan(";
+      it.subplan->Dump();
+      std::cout << ")\n";
+    }
+  }
+
+  std::cout << "GroupBy: " << static_cast<std::string>(group_by_column) << "\n";
+  std::cout << "Aggregate: " << Aggregate::AggregateTypeToString(agg_type)
+            << "(" << static_cast<std::string>(agg_column) << ")\n";
+
+  std::cout << "OrderBy: " << static_cast<std::string>(order_by_column) << " ";
+  std::cout << (order == OrderBy::ASCENDING ? "asc" : "desc") << "\n";
+}
+
+};  // namespace komfydb::execution::logical_plan

--- a/komfydb/execution/logical_plan/logical_plan.h
+++ b/komfydb/execution/logical_plan/logical_plan.h
@@ -1,0 +1,81 @@
+#ifndef __LOGICAL_PLAN_H__
+#define __LOGICAL_PLAN_H__
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
+#include "hsql/SQLParser.h"
+
+#include "komfydb/common/column_ref.h"
+#include "komfydb/execution/aggregate.h"
+#include "komfydb/execution/logical_plan/filter_node.h"
+#include "komfydb/execution/logical_plan/join_node.h"
+#include "komfydb/execution/logical_plan/scan_node.h"
+#include "komfydb/execution/logical_plan/select_node.h"
+#include "komfydb/execution/op_iterator.h"
+#include "komfydb/execution/order_by.h"
+#include "komfydb/storage/catalog.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+using komfydb::storage::Catalog;
+
+};  // namespace
+
+namespace komfydb::execution::logical_plan {
+
+class LogicalPlan {
+ public:
+  LogicalPlan(std::shared_ptr<Catalog> catalog) : catalog(std::move(catalog)) {}
+
+  absl::Status AddFilterColCol(ColumnRef lref, Op op, ColumnRef rref);
+  absl::Status AddFilterColConst(ColumnRef ref, Op op,
+                                 std::unique_ptr<Field> const_field);
+
+  absl::Status AddJoin(ColumnRef lref, Op op, ColumnRef rref);
+  absl::Status AddSubqueryJoin(ColumnRef ref, Op op, LogicalPlan subplan);
+
+  absl::Status AddScan(int table_id, std::string_view alias);
+
+  absl::Status AddGroupBy(ColumnRef ref);
+
+  absl::Status AddAggregate(std::string_view agg_fun, ColumnRef ref);
+
+  absl::Status AddSelect(ColumnRef ref);
+
+  absl::Status AddOrderBy(ColumnRef ref, OrderBy::Order asc);
+
+  absl::StatusOr<common::ColumnRef> GetColumnRef(std::string_view table,
+                                                 std::string_view column);
+
+  absl::StatusOr<common::ColumnRef> GetColumnRef(char* table, char* column);
+
+  absl::StatusOr<common::Type> GetColumnType(ColumnRef ref);
+
+  void Dump();
+
+ private:
+  // Returns InvalidArgumentError if this reference is invalid.
+  absl::Status CheckColumnRef(ColumnRef ref);
+
+  std::shared_ptr<Catalog> catalog;
+  std::vector<FilterNode> filters;
+  std::vector<JoinNode> joins;
+  std::vector<SelectNode> selects;
+  std::vector<ScanNode> scans;
+
+  absl::flat_hash_map<std::string, int> alias_to_id;
+  Aggregate::AggregateType agg_type = Aggregate::NONE;
+  ColumnRef agg_column = {};
+  ColumnRef group_by_column = {};
+  ColumnRef order_by_column = {};
+  OrderBy::Order order;
+};
+
+};  // namespace komfydb::execution::logical_plan
+
+#endif  // __LOGICAL_PLAN_H__

--- a/komfydb/execution/logical_plan/scan_node.h
+++ b/komfydb/execution/logical_plan/scan_node.h
@@ -1,0 +1,22 @@
+#ifndef __SCAN_NODE_H__
+#define __SCAN_NODE_H__
+
+#include <string>
+
+namespace komfydb::execution::logical_plan {
+
+class ScanNode {
+ public:
+  // Table id in the catalog.
+  int id;
+  // Table alias in the query.
+  std::string alias;
+
+  ScanNode(int id, std::string_view alias) : id(id), alias(alias) {}
+
+  operator std::string() const { return std::to_string(id) + ", " + alias; }
+};
+
+};  // namespace komfydb::execution::logical_plan
+
+#endif  // __SCAN_NODE_H__

--- a/komfydb/execution/logical_plan/select_node.h
+++ b/komfydb/execution/logical_plan/select_node.h
@@ -1,0 +1,25 @@
+#ifndef __SELECT_NODE_H__
+#define __SELECT_NODE_H__
+
+#include "komfydb/common/column_ref.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+
+};
+
+namespace komfydb::execution::logical_plan {
+
+class SelectNode {
+ public:
+  ColumnRef ref;
+
+  SelectNode(ColumnRef ref) : ref(ref) {}
+
+  operator std::string() const { return static_cast<std::string>(ref); }
+};
+
+};  // namespace komfydb::execution::logical_plan
+
+#endif  // __SELECT_LIST_NODE_H__

--- a/komfydb/execution/op.cc
+++ b/komfydb/execution/op.cc
@@ -1,0 +1,55 @@
+#include "komfydb/execution/op.h"
+
+#include "absl/container/flat_hash_map.h"
+
+namespace komfydb::execution {
+
+void Op::Flip() {
+  switch (value) {
+    case GREATER_THAN:
+      value = LESS_THAN;
+      break;
+    case GREATER_THAN_OR_EQ:
+      value = LESS_THAN_OR_EQ;
+      break;
+    case LESS_THAN:
+      value = GREATER_THAN;
+      break;
+    case LESS_THAN_OR_EQ:
+      value = GREATER_THAN_OR_EQ;
+    case EQUALS:
+    case NOT_EQUALS:
+    case LIKE:
+      break;
+  }
+}
+
+absl::StatusOr<Op> Op::StrToOp(std::string_view op) {
+  static const absl::flat_hash_map<std::string, Op::Value> str_to_op = {
+      {"=", Op::EQUALS},       {"==", Op::EQUALS},
+      {">", Op::GREATER_THAN}, {">=", Op::GREATER_THAN_OR_EQ},
+      {"<", Op::LESS_THAN},    {"<=", Op::LESS_THAN_OR_EQ},
+      {"LIKE", Op::LIKE},      {"~", Op::LIKE},
+      {"!=", Op::NOT_EQUALS},  {"<>", Op::NOT_EQUALS},
+  };
+
+  auto it = str_to_op.find(op);
+  if (it == str_to_op.end()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat(op, " is not a valid operator\n."));
+  }
+  return Op(it->second);
+}
+
+Op::operator std::string() const {
+  static const absl::flat_hash_map<Op::Value, std::string> op_to_str = {
+      {EQUALS, "="},           {GREATER_THAN, ">"},        {LESS_THAN, "<"},
+      {LESS_THAN_OR_EQ, "<="}, {GREATER_THAN_OR_EQ, ">="}, {LIKE, "~"},
+      {NOT_EQUALS, "!="},
+  };
+
+  assert(op_to_str.contains(value));
+  return op_to_str.find(value)->second;
+}
+
+};  // namespace komfydb::execution

--- a/komfydb/execution/op.h
+++ b/komfydb/execution/op.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <string>
 
+#include "absl/status/statusor.h"
+
 namespace komfydb::execution {
 
 class Op {
@@ -21,7 +23,12 @@ class Op {
 
   Op(Value value) : value(value) {}
 
+  // Change '<' to '>', '<=' to '>=' and so on.
+  void Flip();
+
   operator std::string() const;
+
+  static absl::StatusOr<Op> StrToOp(std::string_view op);
 };
 
 };  // namespace komfydb::execution

--- a/komfydb/parser.cc
+++ b/komfydb/parser.cc
@@ -1,0 +1,376 @@
+#include "komfydb/parser.h"
+#include <hsql/sql/SelectStatement.h>
+
+#include <vector>
+
+#include "common/column_ref.h"
+#include "execution/logical_plan/join_node.h"
+#include "execution/order_by.h"
+#include "hsql/sql/Expr.h"
+#include "hsql/sql/SQLStatement.h"
+#include "hsql/sql/Table.h"
+#include "hsql/util/sqlhelper.h"
+
+#include "common/string_field.h"
+#include "glog/logging.h"
+#include "utils/status_macros.h"
+
+namespace {
+
+using komfydb::common::ColumnRef;
+using komfydb::common::Type;
+
+std::string GetErrorMessage(std::string_view query,
+                            hsql::SQLParserResult& result) {
+  std::string indication = absl::StrCat(
+      std::string(result.errorColumn(), ' ') + "^ ", result.errorMsg());
+  std::string msg =
+      absl::StrCat("Parsing error:\n\t", query, "\n\t", indication);
+  return msg;
+}
+
+absl::StatusOr<Op> HsqlOpToOp(hsql::OperatorType op_type) {
+  switch (op_type) {
+    case hsql::OperatorType::kOpGreater:
+      return Op(Op::Value::GREATER_THAN);
+    case hsql::OperatorType::kOpGreaterEq:
+      return Op(Op::Value::GREATER_THAN_OR_EQ);
+    case hsql::OperatorType::kOpLess:
+      return Op(Op::Value::LESS_THAN);
+    case hsql::OperatorType::kOpLessEq:
+      return Op(Op::Value::LESS_THAN_OR_EQ);
+    case hsql::OperatorType::kOpLike:
+      return Op(Op::Value::LIKE);
+    case hsql::OperatorType::kOpEquals:
+      return Op(Op::Value::EQUALS);
+    case hsql::OperatorType::kOpNotEquals:
+      return Op(Op::Value::NOT_EQUALS);
+    default:
+      return absl::InvalidArgumentError(
+          absl::StrCat("Unsupported binary operator ", op_type));
+  }
+}
+
+bool isConstantExpr(const hsql::Expr* expr) {
+  return expr->type == hsql::ExprType::kExprColumnRef ||
+         expr->type == hsql::ExprType::kExprLiteralInt ||
+         expr->type == hsql::ExprType::kExprLiteralString;
+}
+
+absl::Status CompareTypes(ColumnRef lref, ColumnRef rref, LogicalPlan& lp) {
+  ASSIGN_OR_RETURN(Type lt, lp.GetColumnType(lref));
+  ASSIGN_OR_RETURN(Type rt, lp.GetColumnType(rref));
+
+  if (lt != rt) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Cannot compare columns with different type: ",
+        static_cast<std::string>(lref), ":", static_cast<std::string>(lt), " ",
+        static_cast<std::string>(rref), ":", static_cast<std::string>(rt)));
+  }
+  return absl::OkStatus();
+}
+
+static const std::string unsuported_msg =
+    "Only supported operators are e1 AND e2 and simple binary "
+    "expressions like A op B, where A, B are constatns, table columns "
+    "or B is a subquery.";
+
+};  // namespace
+
+namespace komfydb {
+
+absl::Status Parser::ParseFromClause(LogicalPlan& lp,
+                                     const hsql::TableRef* from) {
+  std::vector<std::string_view> names;
+  std::vector<std::string_view> aliases;
+  std::vector<int> ids;
+
+  switch (from->type) {
+    case hsql::TableRefType::kTableName:
+      names.push_back(from->name);
+      aliases.push_back(from->getName());
+      break;
+    case hsql::TableRefType::kTableCrossProduct:
+      for (const hsql::TableRef* tbl : *from->list) {
+        if (tbl->type != hsql::TableRefType::kTableName) {
+          return absl::InvalidArgumentError(
+              "Only table names/aliases in FROM currently supported");
+        }
+        names.push_back(tbl->name);
+        aliases.push_back(tbl->getName());
+      }
+      break;
+    default:
+      return absl::InvalidArgumentError(
+          "Only table names/aliases in FROM currently supported");
+  }
+
+  for (auto name : names) {
+    ASSIGN_OR_RETURN(int id, catalog->GetTableId(name));
+    ids.push_back(id);
+  }
+
+  for (int i = 0; i < aliases.size(); i++) {
+    RETURN_IF_ERROR(lp.AddScan(ids[i], aliases[i]));
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status Parser::ParseSimpleExpression(LogicalPlan& lp, hsql::Expr* lexpr,
+                                           Op op, hsql::Expr* rexpr) {
+  LOG(INFO) << "Parsing simple expression";
+  bool is_join = false;
+  // This expr creates join if and only if we have a binary expr A op B where
+  // - Both A, B are column references from different tables,
+  // - A is a column reference and B is a nested query
+  if (lexpr->isType(hsql::ExprType::kExprColumnRef) &&
+      rexpr->isType(hsql::ExprType::kExprColumnRef)) {
+    ASSIGN_OR_RETURN(ColumnRef lref,
+                     lp.GetColumnRef(lexpr->table, lexpr->name));
+    ASSIGN_OR_RETURN(ColumnRef rref,
+                     lp.GetColumnRef(rexpr->table, rexpr->name));
+    if (lref.table != rref.table) {
+      is_join = true;
+    }
+  } else if (rexpr->isType(hsql::ExprType::kExprSelect)) {
+    if (!lexpr->isType(hsql::ExprType::kExprColumnRef)) {
+      return absl::InvalidArgumentError(
+          absl::StrCat("Expression with nested query requires left operand to "
+                       "be a column reference."));
+    }
+    is_join = true;
+  }
+  if (!isConstantExpr(lexpr) ||
+      (!isConstantExpr(rexpr) && !rexpr->isType(hsql::ExprType::kExprSelect))) {
+    return absl::InvalidArgumentError(unsuported_msg);
+  }
+  LOG(INFO) << "Is_join: " << is_join;
+
+  if (is_join) {
+    ASSIGN_OR_RETURN(ColumnRef lref,
+                     lp.GetColumnRef(lexpr->table, lexpr->name));
+    if (rexpr->isType(hsql::ExprType::kExprColumnRef)) {
+      ASSIGN_OR_RETURN(ColumnRef rref,
+                       lp.GetColumnRef(rexpr->table, rexpr->name));
+      RETURN_IF_ERROR(CompareTypes(lref, rref, lp));
+      RETURN_IF_ERROR(lp.AddJoin(lref, op, rref));
+      return absl::OkStatus();
+    }
+    // Else it's a subquery join.
+    ASSIGN_OR_RETURN(LogicalPlan subplan, ParseSelectStatement(rexpr->select));
+    // TODO: Compare types of lref and first field of the subplan.
+    RETURN_IF_ERROR(lp.AddSubqueryJoin(lref, op, std::move(subplan)));
+    return absl::OkStatus();
+  }
+
+  // Else we got a filter.
+  if (lexpr->isLiteral() && rexpr->isLiteral()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Filters with two literals are unsupported."));
+  }
+  // For convenience, make left always a column ref.
+  if (lexpr->isLiteral()) {
+    hsql::Expr* tmp = lexpr;
+    lexpr = rexpr;
+    rexpr = tmp;
+    op.Flip();
+  }
+  ASSIGN_OR_RETURN(ColumnRef lref, lp.GetColumnRef(lexpr->table, lexpr->name));
+
+  // column op const
+  if (rexpr->isLiteral()) {
+    ASSIGN_OR_RETURN(Type t, lp.GetColumnType(lref));
+    std::unique_ptr<Field> const_field;
+    switch (t.GetValue()) {
+      case Type::INT:
+        if (rexpr->type != hsql::ExprType::kExprLiteralInt) {
+          return absl::InvalidArgumentError(
+              absl::StrCat("Cannot compare string literal with int column ",
+                           static_cast<std::string>(lref)));
+        }
+        const_field = std::make_unique<IntField>(rexpr->ival);
+        break;
+      case Type::STRING:
+        if (rexpr->type != hsql::ExprType::kExprLiteralString) {
+          return absl::InvalidArgumentError(
+              absl::StrCat("Cannot compare int literal with string column ",
+                           static_cast<std::string>(lref)));
+        }
+        const_field = std::make_unique<StringField>(rexpr->name);
+        break;
+    }
+    RETURN_IF_ERROR(lp.AddFilterColConst(lref, op, std::move(const_field)));
+    return absl::OkStatus();
+  }
+
+  // column op column
+  ASSIGN_OR_RETURN(ColumnRef rref, lp.GetColumnRef(rexpr->table, rexpr->name));
+  RETURN_IF_ERROR(CompareTypes(lref, rref, lp));
+  RETURN_IF_ERROR(lp.AddFilterColCol(lref, op, rref));
+
+  return absl::OkStatus();
+}
+
+absl::Status Parser::ParseWhereExpression(LogicalPlan& lp, hsql::Expr* expr) {
+  if (expr == nullptr) {
+    return absl::OkStatus();
+  }
+  switch (expr->type) {
+    case hsql::ExprType::kExprOperator:
+      switch (expr->opType) {
+        case hsql::OperatorType::kOpAnd:
+          RETURN_IF_ERROR(ParseWhereExpression(lp, expr->expr));
+          RETURN_IF_ERROR(ParseWhereExpression(lp, expr->expr2));
+          break;
+        default:
+          ASSIGN_OR_RETURN(Op op, HsqlOpToOp(expr->opType));
+          RETURN_IF_ERROR(
+              ParseSimpleExpression(lp, expr->expr, op, expr->expr2));
+          break;
+      }
+      break;
+    default:
+      return absl::InvalidArgumentError(unsuported_msg);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Parser::ParseGroupBy(LogicalPlan& lp,
+                                  hsql::GroupByDescription* descr) {
+  if (descr == nullptr) {
+    return absl::OkStatus();
+  }
+  if (descr->having) {
+    return absl::InvalidArgumentError("Having expressions are unsupported.");
+  }
+  if (descr->columns->size() != 1) {
+    return absl::InvalidArgumentError(
+        "GroupBy with multiple fields is unsupported.");
+  }
+
+  hsql::Expr* expr = descr->columns->back();
+  if (!expr->isType(hsql::ExprType::kExprColumnRef)) {
+    return absl::InvalidArgumentError(
+        "GroupBy expression must be a column reference.");
+  }
+
+  ASSIGN_OR_RETURN(ColumnRef ref, lp.GetColumnRef(expr->table, expr->name));
+  RETURN_IF_ERROR(lp.AddGroupBy(ref));
+
+  return absl::OkStatus();
+}
+
+absl::Status Parser::ParseColumnSelection(LogicalPlan& lp,
+                                          std::vector<hsql::Expr*>* columns) {
+  for (auto& it : *columns) {
+    ColumnRef ref;
+    hsql::Expr* col;
+    switch (it->type) {
+      case hsql::ExprType::kExprFunctionRef: {
+        if (it->exprList == nullptr || it->exprList->size() != 1) {
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Only one column name as aggregate argument supported."));
+        }
+        col = it->exprList->back();
+        if (!col->isType(hsql::ExprType::kExprColumnRef) &&
+            !col->isType(hsql::ExprType::kExprStar)) {
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Only one column name as aggregate argument supported."));
+        }
+        if (col->isType(hsql::ExprType::kExprStar)) {
+          ref = common::COLUMN_REF_STAR;
+        } else {
+          ASSIGN_OR_RETURN(ref, lp.GetColumnRef(col->table, col->name));
+        }
+        RETURN_IF_ERROR(lp.AddAggregate(it->name, ref));
+        break;
+      }
+      case hsql::ExprType::kExprColumnRef: {
+        ASSIGN_OR_RETURN(ref, lp.GetColumnRef(it->table, it->name));
+        RETURN_IF_ERROR(lp.AddSelect(ref));
+        break;
+      }
+      case hsql::ExprType::kExprStar: {
+        RETURN_IF_ERROR(lp.AddSelect(common::COLUMN_REF_STAR));
+        break;
+      }
+      default:
+        return absl::InvalidArgumentError(
+            "Possible selects are only star, aggregates and column "
+            "references.");
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status Parser::ParseOrderBy(LogicalPlan& lp,
+                                  std::vector<hsql::OrderDescription*>* descr) {
+  if (!descr) {
+    return absl::OkStatus();
+  }
+
+  if (descr->size() != 1) {
+    return absl::InvalidArgumentError("Order by only by one column supported.");
+  }
+  hsql::OrderDescription* order_descr = descr->back();
+  hsql::Expr* expr = order_descr->expr;
+  execution::OrderBy::Order asc =
+      order_descr->type == hsql::OrderType::kOrderAsc
+          ? execution::OrderBy::ASCENDING
+          : execution::OrderBy::DESCENDING;
+
+  if (!expr->isType(hsql::ExprType::kExprColumnRef)) {
+    return absl::InvalidArgumentError("Order by only by one column supported.");
+  }
+
+  ASSIGN_OR_RETURN(ColumnRef ref, lp.GetColumnRef(expr->table, expr->name));
+  RETURN_IF_ERROR(lp.AddOrderBy(ref, asc));
+  return absl::OkStatus();
+}
+
+absl::StatusOr<LogicalPlan> Parser::ParseSelectStatement(
+    const hsql::SelectStatement* stmt) {
+  LogicalPlan lp(catalog);
+
+  LOG(INFO) << "Parsing From clause";
+  RETURN_IF_ERROR(ParseFromClause(lp, stmt->fromTable));
+  LOG(INFO) << "Parsing where clause";
+  RETURN_IF_ERROR(ParseWhereExpression(lp, stmt->whereClause));
+  LOG(INFO) << "Parsing group by";
+  RETURN_IF_ERROR(ParseGroupBy(lp, stmt->groupBy));
+  LOG(INFO) << "Parsing column selection";
+  RETURN_IF_ERROR(ParseColumnSelection(lp, stmt->selectList));
+  LOG(INFO) << "Parsing order by";
+  RETURN_IF_ERROR(ParseOrderBy(lp, stmt->order));
+
+  return std::move(lp);
+}
+
+absl::StatusOr<LogicalPlan> Parser::ParseQuery(std::string_view query) {
+  LOG(INFO) << "Parsing query: " << query;
+  hsql::SQLParserResult result;
+  hsql::SQLParser::parse(std::string(query), &result);
+  if (!result.isValid()) {
+    return absl::InvalidArgumentError(GetErrorMessage(query, result));
+  }
+
+  const std::vector<hsql::SQLStatement*> stmts = result.getStatements();
+  if (stmts.size() != 1) {
+    return absl::UnimplementedError(
+        "Currently only one statement per query is supported.");
+  }
+
+  const hsql::SQLStatement* stmt = stmts.back();
+
+  if (!stmt->isType(hsql::StatementType::kStmtSelect)) {
+    return absl::UnimplementedError(
+        "Currently only query statements are supported.");
+  }
+
+  const hsql::SelectStatement* select =
+      static_cast<const hsql::SelectStatement*>(stmt);
+  return ParseSelectStatement(select);
+}
+
+};  // namespace komfydb

--- a/komfydb/parser.h
+++ b/komfydb/parser.h
@@ -1,0 +1,48 @@
+#ifndef __PARSER_H__
+#define __PARSER_H__
+
+#include <hsql/sql/SelectStatement.h>
+#include "absl/status/statusor.h"
+#include "hsql/SQLParser.h"
+
+#include "komfydb/execution/logical_plan/logical_plan.h"
+
+namespace {
+
+using komfydb::execution::logical_plan::LogicalPlan;
+
+};
+
+namespace komfydb {
+
+class Parser {
+ private:
+  std::shared_ptr<Catalog> catalog;
+
+  absl::StatusOr<LogicalPlan> ParseSelectStatement(
+      const hsql::SelectStatement* stmt);
+
+  absl::Status ParseFromClause(LogicalPlan& lp, const hsql::TableRef* from);
+
+  absl::Status ParseSimpleExpression(LogicalPlan& lp, hsql::Expr* lexpr, Op op,
+                                     hsql::Expr* rexpr);
+
+  absl::Status ParseWhereExpression(LogicalPlan& lp, hsql::Expr* expr);
+
+  absl::Status ParseGroupBy(LogicalPlan& lp, hsql::GroupByDescription* descr);
+
+  absl::Status ParseColumnSelection(LogicalPlan& lp,
+                                    std::vector<hsql::Expr*>* columns);
+
+  absl::Status ParseOrderBy(LogicalPlan& lp,
+                            std::vector<hsql::OrderDescription*>* descr);
+
+ public:
+  Parser(std::shared_ptr<Catalog> catalog) : catalog(std::move(catalog)) {}
+
+  absl::StatusOr<LogicalPlan> ParseQuery(std::string_view query);
+};
+
+};  // namespace komfydb
+
+#endif  // __PARSER_H__

--- a/komfydb/parser_repl.cc
+++ b/komfydb/parser_repl.cc
@@ -1,0 +1,60 @@
+#include <hsql/sql/SelectStatement.h>
+#include <readline/history.h>
+#include <readline/readline.h>
+
+#include <iostream>
+
+#include "execution/logical_plan/logical_plan.h"
+#include "glog/logging.h"
+#include "hsql/SQLParser.h"
+#include "hsql/util/sqlhelper.h"
+
+#include "komfydb/common/td_item.h"
+#include "komfydb/common/type.h"
+#include "komfydb/database.h"
+#include "komfydb/execution/order_by.h"
+#include "komfydb/execution/seq_scan.h"
+#include "komfydb/parser.h"
+#include "komfydb/storage/heap_page.h"
+#include "komfydb/storage/table_iterator.h"
+#include "komfydb/utils/status_macros.h"
+
+using namespace komfydb;
+
+int main(int argc, char* argv[]) {
+  google::InitGoogleLogging(argv[0]);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  LOG(INFO) << "Parser testing!";
+
+  absl::StatusOr<Database> db =
+      Database::LoadSchema("komfydb/testdata/database_catalog_test.txt");
+  if (!db.ok()) {
+    LOG(ERROR) << "LoadSchema error: " << db.status().message();
+  }
+
+  std::shared_ptr<Catalog> catalog = db->GetCatalog();
+  std::shared_ptr<BufferPool> buffer_pool = db->GetBufferPool();
+  Parser parser(std::move(catalog));
+
+  char* query;
+  while ((query = readline("KomfyDB> ")) != nullptr) {
+    if (!strlen(query)) {
+      continue;
+    }
+    add_history(query);
+    hsql::SQLParserResult result;
+    hsql::SQLParser::parse(query, &result);
+
+    absl::StatusOr<execution::logical_plan::LogicalPlan> lp =
+        parser.ParseQuery(query);
+    if (!lp.ok()) {
+      LOG(ERROR) << "Parsing error: " << lp.status().message();
+    } else {
+      LOG(INFO) << "Parsing ok!";
+      lp->Dump();
+    }
+
+    free(query);
+  }
+}

--- a/komfydb/parser_test.cc
+++ b/komfydb/parser_test.cc
@@ -1,0 +1,74 @@
+#include "komfydb/parser.h"
+
+#include "gtest/gtest.h"
+
+#include "absl/status/statusor.h"
+
+#include "komfydb/database.h"
+
+namespace {
+
+using komfydb::Database;
+using komfydb::Parser;
+using komfydb::execution::logical_plan::LogicalPlan;
+
+class ParserTest
+    : public ::testing::TestWithParam<std::tuple<std::string, std::string>> {
+ protected:
+  std::unique_ptr<Database> db;
+  std::unique_ptr<Parser> parser;
+  absl::StatusOr<LogicalPlan> lp;
+
+  void SetUp() override {
+    db = std::make_unique<Database>(std::move(
+        Database::LoadSchema("komfydb/testdata/database_catalog_test.txt")
+            .value()));
+    parser = std::make_unique<Parser>(db->GetCatalog());
+  }
+};
+
+// TODO: This isn't unfortunatelly a unit test, as we need to create a 'true'
+// database object... It would be nice to create some mock objects for catalog
+// and database for unit tests.
+TEST_P(ParserTest, Queries) {
+  auto [query, result] = GetParam();
+  lp = parser->ParseQuery(query);
+  if (result == "OK") {
+    EXPECT_TRUE(lp.ok());
+  } else {
+    EXPECT_FALSE(lp.ok());
+    EXPECT_EQ(lp.status().message(), result);
+  }
+}
+
+const std::vector<std::tuple<std::string, std::string>> test_queries = {
+    {"SELECT * FROM first_table", "OK"},
+    {"SELECT * FROM first_table WHERE name1 > name3", "OK"},
+    {"SELECT * FROM first_table WHERE name1 > name2",
+     "Cannot compare columns with different type: first_table.name1:int "
+     "first_table.name2:str"},
+    {"SELECT no_name FROM first_table",
+     "Column no_name does not appear in any table"},
+    {"SELECT t1.name1, t2.name2, t3.name1 "
+     "FROM first_table t1, second_table t2, first_table t3 "
+     "WHERE t1.name1 == t3.name3 "
+     "AND t2.name4 LIKE t2.name2",
+     "OK"},
+    {"SELECT * FROM first_table WHERE name1 > (SELECT * FROM first_table)",
+     "OK"},
+    {"SELECT * FROM first_table WHERE (SELECT * FROM first_table) < name1",
+     "Only supported operators are e1 AND e2 and simple binary expressions "
+     "like A op B, where A, B are constatns, table columns or B is a "
+     "subquery."},
+    {"SELECT * FROM first_table WHERE 1 > 2",
+     "Filters with two literals are unsupported."},
+    {"SELECT * FROM first_table WHERE name1 > 2", "OK"},
+    {"SELECT * FROM first_table WHERE name2 > 2",
+     "Cannot compare int literal with string column first_table.name2"},
+    {"SELECT * FROM first_table, second_table WHERE name1 > 2",
+     "Column name1 without table name is ambigous"},
+};
+
+INSTANTIATE_TEST_SUITE_P(Queries, ParserTest, testing::ValuesIn(test_queries));
+
+};  // namespace

--- a/komfydb/sql_parser_test.cc
+++ b/komfydb/sql_parser_test.cc
@@ -1,3 +1,4 @@
+#include <hsql/sql/SelectStatement.h>
 #include <readline/history.h>
 #include <readline/readline.h>
 
@@ -19,6 +20,9 @@ int main() {
     if (result.isValid() && result.size() > 0) {
       const hsql::SQLStatement* statement = result.getStatement(0);
       hsql::printStatementInfo(statement);
+      const hsql::SelectStatement* select =
+          static_cast<const hsql::SelectStatement*>(statement);
+      std::cout << select->fromTable->type << "\n";
     } else {
       std::cout << "Parsing error [col " << result.errorColumn()
                 << "]: " << result.errorMsg() << "\n";

--- a/komfydb/storage/catalog.cc
+++ b/komfydb/storage/catalog.cc
@@ -23,8 +23,8 @@ absl::StatusOr<V> StatusOrMapElement(const absl::flat_hash_map<K, V>& map,
 
 namespace komfydb::storage {
 
-void Catalog::AddTable(std::unique_ptr<DbFile> file, std::string name,
-                       std::string primary_key) {
+void Catalog::AddTable(std::unique_ptr<DbFile> file, std::string_view name,
+                       std::string_view primary_key) {
   LOG(INFO) << "Adding table: tid=" << file->GetId() << " name=" << name
             << " pk=" << primary_key;
   int id = file->GetId();
@@ -35,7 +35,7 @@ void Catalog::AddTable(std::unique_ptr<DbFile> file, std::string name,
   table_name_to_id[name] = id;
 }
 
-void Catalog::AddTable(std::unique_ptr<DbFile> file, std::string name) {
+void Catalog::AddTable(std::unique_ptr<DbFile> file, std::string_view name) {
   AddTable(std::move(file), name, "");
 }
 
@@ -43,8 +43,8 @@ void Catalog::AddTable(std::unique_ptr<DbFile> file) {
   AddTable(std::move(file), common::GenerateUuidV4());
 }
 
-absl::StatusOr<int> Catalog::GetTableId(std::string name) const {
-  return StatusOrMapElement(table_name_to_id, name);
+absl::StatusOr<int> Catalog::GetTableId(std::string_view name) const {
+  return StatusOrMapElement(table_name_to_id, std::string(name));
 }
 
 absl::StatusOr<std::string> Catalog::GetTableName(int table_id) const {

--- a/komfydb/storage/catalog.h
+++ b/komfydb/storage/catalog.h
@@ -24,14 +24,14 @@ class Catalog {
 
   // Add table to catalog. If table with given name exists, then remove it
   // and add this one. If file with given id exists, also replace it.
-  void AddTable(std::unique_ptr<DbFile> file, std::string name,
-                std::string primary_key);
+  void AddTable(std::unique_ptr<DbFile> file, std::string_view name,
+                std::string_view primary_key);
 
-  void AddTable(std::unique_ptr<DbFile> file, std::string name);
+  void AddTable(std::unique_ptr<DbFile> file, std::string_view name);
 
   void AddTable(std::unique_ptr<DbFile> file);
 
-  absl::StatusOr<int> GetTableId(std::string name) const;
+  absl::StatusOr<int> GetTableId(std::string_view name) const;
 
   absl::StatusOr<std::string> GetTableName(int table_id) const;
 

--- a/komfydb/utils/BUILD
+++ b/komfydb/utils/BUILD
@@ -7,6 +7,7 @@ cc_library(
     "status_builder.h",
   ],
   deps = [
+    "//komfydb/common:column_ref",
     "@com_google_absl//absl/status:statusor",
     "@com_google_absl//absl/status",
     "@com_google_absl//absl/strings",

--- a/komfydb/utils/utility.h
+++ b/komfydb/utils/utility.h
@@ -6,6 +6,9 @@
 #include <vector>
 
 #include "absl/random/random.h"
+#include "absl/status/statusor.h"
+
+#include "komfydb/common/column_ref.h"
 
 namespace komfydb::common {
 


### PR DESCRIPTION
Queries for KomfyDB are limited and support only a minor part of the SQL
syntax. At the moment supported queries are of the form:
`SELECT n1, ..., nk
 FROM t1 a1, ..., tm am
 WHERE e1 AND ... AND el
 ORDER BY col
 GROUP BY col`
where:
- ni are column references (can be either alias.column or column if the
  column name is unambigous in given tables), aggregate functions or
  star (*)
- ti are table names and ai are aliases for these tables in the given
  query (can be possibly empty),
- ei are expressions of the form A op A'. Either A or A' can be a
  constant or column reference. At least one of A or A' must be a column
  reference.
- col are column references.

In KomfyDB filters and joins are expressed using expressions (of the
form A op A') in the WHERE clause. There are a couple of possibilities:
- Exactly one of A and A' is a column reference and exaclty one of them
  is a constant. Then the expression corresponds to a filter.
- Both A and A' are a column reference. If both A and A' reference a
  column in the same table, then A op A' corresponds to a filter.
  Otherwise the expression corresponds to a join on the referenced
  tables. We join only tuples that satisfy the condition.
- A is a column reference and A' is a subquery. This is always a join on
  the first column of resulting tuples in the subquery and the
  refernced column in A.