### PR TITLE
Got rid of HasNext

### DIFF
--- a/komfydb/execution/op_iterator.h
+++ b/komfydb/execution/op_iterator.h
@@ -24,8 +24,6 @@ class OpIterator {
 
   virtual void Close() = 0;
 
-  virtual bool HasNext() = 0;
-
   virtual absl::StatusOr<Record> Next() = 0;
 
   virtual TupleDesc* GetTupleDesc() = 0;

--- a/komfydb/execution/order_by.h
+++ b/komfydb/execution/order_by.h
@@ -28,8 +28,6 @@ class OrderBy : public OpIterator {
 
   void Close() override;
 
-  bool HasNext() override;
-
   absl::StatusOr<Record> Next() override;
 
   TupleDesc* GetTupleDesc() override;

--- a/komfydb/execution/seq_scan.cc
+++ b/komfydb/execution/seq_scan.cc
@@ -53,10 +53,6 @@ std::string SeqScan::GetAlias() {
   return table_alias;
 }
 
-bool SeqScan::HasNext() {
-  return iterator->HasNext();
-}
-
 absl::StatusOr<Record> SeqScan::Next() {
   return iterator->Next();
 }

--- a/komfydb/execution/seq_scan.h
+++ b/komfydb/execution/seq_scan.h
@@ -39,8 +39,6 @@ class SeqScan : public OpIterator {
 
   std::string GetAlias();
 
-  bool HasNext() override;
-
   absl::StatusOr<Record> Next() override;
 
   TupleDesc* GetTupleDesc() override;

--- a/komfydb/komfydb.cc
+++ b/komfydb/komfydb.cc
@@ -61,9 +61,9 @@ int main(int argc, char* argv[]) {
   LOG(INFO) << "Opened order_by on table "
             << catalog->GetTableName(table_id).value();
 
-  while (order_by->HasNext()) {
-    Record record = std::move(order_by->Next().value());
-    std::cout << static_cast<std::string>(record) << "\n";
+  absl::StatusOr<Record> rec;
+  while ((rec = order_by->Next()).ok()) {
+    std::cout << static_cast<std::string>(*rec) << "\n";
   }
   order_by->Close();
 }

--- a/komfydb/storage/table_iterator.cc
+++ b/komfydb/storage/table_iterator.cc
@@ -38,22 +38,9 @@ absl::Status TableIterator::Open() {
 
 void TableIterator::Close() {}
 
-bool TableIterator::HasNext() {
-  if (current_tuple != records.end()) {
-    return true;
-  }
-
-  absl::Status status = LoadNextPage();
-  if (absl::IsOutOfRange(status)) {
-    return false;
-  }
-  assert(status.ok());
-  return HasNext();
-}
-
 absl::StatusOr<Record> TableIterator::Next() {
-  if (!HasNext()) {
-    return absl::OutOfRangeError("No more records in this table");
+  if (current_tuple == records.end()) {
+    RETURN_IF_ERROR(LoadNextPage());
   }
   return std::move(*current_tuple++);
 }

--- a/komfydb/storage/table_iterator.h
+++ b/komfydb/storage/table_iterator.h
@@ -38,8 +38,6 @@ class TableIterator {
 
   void Close();
 
-  bool HasNext();
-
   absl::StatusOr<Record> Next();
 
   absl::StatusOr<TupleDesc*> GetTupleDesc();


### PR DESCRIPTION
We came to a conclusion that `HasNext` is irrelevant, as it seems unlikely to ever call `HasNext` without succeeding call to `Next`. As the implementation of `HasNext` complicated implementations of `Next` we decided to get rid of it entirely.