### PR TITLE
Remove tuple descriptor from tuples.

### DIFF
--- a/komfydb/common/tuple.h
+++ b/komfydb/common/tuple.h
@@ -18,26 +18,24 @@ namespace komfydb::common {
 // representing a Tuple in memory.
 class Tuple {
  protected:
-  const TupleDesc* tuple_desc;
-
   std::vector<std::unique_ptr<Field>> fields;
 
   void swap(Tuple& t);
 
  public:
-  Tuple(const TupleDesc* tuple_desc);
+  Tuple(int size);
 
   Tuple(const Tuple& t);
 
   Tuple(Tuple&& tuple) = default;
 
-  Tuple(Tuple& t1, Tuple&& t2, TupleDesc* joined_td);
+  Tuple(Tuple& t1, Tuple&& t2);
 
   virtual ~Tuple() = default;
 
   Tuple& operator=(const Tuple& t);
 
-  const TupleDesc* GetTupleDesc();
+  int Size() const;
 
   absl::StatusOr<Field*> GetField(int i) const;
 
@@ -71,12 +69,6 @@ class Tuple {
     }
     return h;
   }
-
-  // TODO(Iterator)
-  // std::vector<Field> GetFields();
-
-  // Wtf should this do? lol
-  // void ResetTupleDesc(TupleDesc tuple_desc);
 };
 
 };  // namespace komfydb::common

--- a/komfydb/common/tuple_test.cc
+++ b/komfydb/common/tuple_test.cc
@@ -13,10 +13,8 @@ TEST(Tuple, StringConversion) {
   Type int_t(Type::INT);
   Type str_t(Type::STRING);
   std::vector<Type> tv{int_t, str_t};
-  std::vector<std::string> nv{"f1", "f2"};
 
-  TupleDesc tuple_desc(tv, nv);
-  Tuple tuple(&tuple_desc);
+  Tuple tuple(tv.size());
 
   EXPECT_TRUE(tuple.SetField(0, std::make_unique<IntField>(1)).ok());
 
@@ -31,9 +29,8 @@ TEST(Tuple, Comparison) {
                                     Type::STRING};
   const std::vector<Type> types2 = {Type::INT, Type::STRING};
 
-  const TupleDesc td1(types1), td2(types2);
-
-  Tuple t1(&td1), t2(&td1), t3(&td1), t4(&td2);
+  Tuple t1(types1.size()), t2(types1.size()), t3(types1.size()),
+      t4(types2.size());
   ASSERT_TRUE(t1.SetField(0, std::make_unique<IntField>(1)).ok());
   ASSERT_TRUE(t1.SetField(1, std::make_unique<StringField>("a")).ok());
   ASSERT_TRUE(t1.SetField(2, std::make_unique<IntField>(2)).ok());
@@ -63,14 +60,13 @@ TEST(Tuple, Comparison) {
 TEST(Tuple, CopyAssignment) {
   const std::vector<Type> types1 = {Type::INT, Type::STRING, Type::INT,
                                     Type::STRING};
-  const TupleDesc tuple_desc(types1);
-  Tuple t1(&tuple_desc);
+  Tuple t1(types1.size());
   ASSERT_TRUE(t1.SetField(0, std::make_unique<IntField>(1)).ok());
   ASSERT_TRUE(t1.SetField(1, std::make_unique<StringField>("a")).ok());
   ASSERT_TRUE(t1.SetField(2, std::make_unique<IntField>(2)).ok());
   ASSERT_TRUE(t1.SetField(3, std::make_unique<StringField>("b")).ok());
 
-  Tuple t2(&tuple_desc);
+  Tuple t2(types1.size());
   t2 = t1;
   Tuple t3(t1);
 

--- a/komfydb/custom_hash_test.cc
+++ b/komfydb/custom_hash_test.cc
@@ -63,8 +63,8 @@ TEST(Tuple, SupportsAbslHash) {
       std::make_unique<StringField>("kappa kappa");
   std::unique_ptr<StringField> str3 = std::make_unique<StringField>("---");
   std::unique_ptr<StringField> str4 = std::make_unique<StringField>("");
-  Tuple t1(&tuple_desc), t2(&tuple_desc), t3(&tuple_desc2), t4(&tuple_desc2),
-      t5(&tuple_desc3);
+  Tuple t1(types.size()), t2(types.size()), t3(types2.size()),
+      t4(types2.size()), t5(types3.size());
   ASSERT_TRUE(t1.SetField(0, std::move(int1)).ok());
   ASSERT_TRUE(t1.SetField(1, std::move(str1)).ok());
   ASSERT_TRUE(t1.SetField(2, std::move(int2)).ok());

--- a/komfydb/execution/aggregate.cc
+++ b/komfydb/execution/aggregate.cc
@@ -127,7 +127,7 @@ absl::Status Aggregate::PrepareWithGrouping() {
   }
   absl::flat_hash_map<Tuple, AggregateTuple> map;
   TupleDesc groupby_tuple_desc(groupby_types);
-  Tuple group_id(&groupby_tuple_desc);
+  Tuple group_id(groupby_tuple_desc.Length());
 
   ITERATE_RECORDS(child, rec) {
     std::unique_ptr<Record> record = std::move(*rec);
@@ -137,7 +137,7 @@ absl::Status Aggregate::PrepareWithGrouping() {
       RETURN_IF_ERROR(UpdateGroup(&map.at(group_id), aggregate_fields,
                                   aggregate_types, record.get()));
     } else {
-      AggregateTuple new_group(&tuple_desc);
+      AggregateTuple new_group(tuple_desc.Length());
       RETURN_IF_ERROR(InitializeGroup(&new_group, aggregate_fields,
                                       aggregate_types, record.get()));
       map.insert({group_id, new_group});
@@ -153,7 +153,7 @@ absl::Status Aggregate::PrepareWithGrouping() {
 }
 
 absl::Status Aggregate::PrepareNoGrouping() {
-  AggregateTuple result(&tuple_desc);
+  AggregateTuple result(tuple_desc.Length());
   bool initialized = false;
   ITERATE_RECORDS(child, rec) {
     std::unique_ptr<Record> record = std::move(*rec);

--- a/komfydb/execution/aggregate_tuple.cc
+++ b/komfydb/execution/aggregate_tuple.cc
@@ -17,8 +17,7 @@ using komfydb::common::StringField;
 
 namespace komfydb::execution {
 
-AggregateTuple::AggregateTuple(const TupleDesc* tuple_desc)
-    : Tuple(tuple_desc), group_size(1) {}
+AggregateTuple::AggregateTuple(int size) : Tuple(size), group_size(1) {}
 
 AggregateTuple::AggregateTuple(const AggregateTuple& t)
     : Tuple(t), group_size(t.group_size) {}
@@ -33,7 +32,7 @@ void AggregateTuple::IncremetGroupSize() {
 
 absl::Status AggregateTuple::ApplyAggregate(AggregateType aggregate_type, int i,
                                             Field* new_field) {
-  ASSIGN_OR_RETURN(Type type, tuple_desc->GetFieldType(i));
+  Type type = fields[i]->GetType();
   switch (type.GetValue()) {
     case Type::INT: {
       IntField* old_int_field = static_cast<IntField*>(fields[i].get());
@@ -107,7 +106,7 @@ absl::Status AggregateTuple::ApplyAggregate(AggregateType aggregate_type, int i,
 
 absl::Status AggregateTuple::FinalizeAggregates(
     std::vector<AggregateType> aggregate_types) {
-  for (int i = 0; i < tuple_desc->Length(); i++) {
+  for (int i = 0; i < Size(); i++) {
     ASSIGN_OR_RETURN(Field * field, GetField(i));
     switch (aggregate_types[i]) {
       case AggregateType::AVG: {

--- a/komfydb/execution/aggregate_tuple.h
+++ b/komfydb/execution/aggregate_tuple.h
@@ -22,7 +22,7 @@ class AggregateTuple : public Tuple {
   int group_size;
 
  public:
-  AggregateTuple(const TupleDesc* tuple_desc);
+  AggregateTuple(int size);
 
   AggregateTuple(const AggregateTuple& t);
 

--- a/komfydb/execution/insert.cc
+++ b/komfydb/execution/insert.cc
@@ -71,8 +71,7 @@ absl::Status Insert::FetchNext() {
     return absl::OutOfRangeError("No more records in this OpIterator");
   }
   RETURN_IF_ERROR(bufferpool->InsertTuples(std::move(tuples), table_id, tid));
-  next_record =
-      std::make_unique<Record>(&tuple_desc, RecordId(PageId(0, 0), -1));
+  next_record = std::make_unique<Record>(1, RecordId(PageId(0, 0), -1));
   RETURN_IF_ERROR(
       next_record->SetField(0, std::make_unique<IntField>(inserted)));
   return absl::OkStatus();

--- a/komfydb/execution/join.cc
+++ b/komfydb/execution/join.cc
@@ -93,9 +93,9 @@ absl::Status Join::FetchNext() {
     if ((status = r_child->HasNext()).ok()) {
       std::unique_ptr<Record> potential_match = r_child->Next().value();
       if (join_predicate.Filter(*l_child_next, *potential_match)) {
-        next_record = std::make_unique<Record>(Record(
-            Tuple(*l_child_next, std::move(*potential_match), &tuple_desc),
-            joined_record_id));
+        next_record = std::make_unique<Record>(
+            Record(Tuple(*l_child_next, std::move(*potential_match)),
+                   joined_record_id));
         return absl::OkStatus();
       }
     } else if (absl::IsOutOfRange(status)) {

--- a/komfydb/execution/project.cc
+++ b/komfydb/execution/project.cc
@@ -51,8 +51,8 @@ absl::Status Project::Rewind() {
 
 absl::Status Project::FetchNext() {
   ASSIGN_OR_RETURN(std::unique_ptr<Record> record, child->Next());
-  Tuple new_tuple(&tuple_desc);
   int num_of_fields = tuple_desc.Length();
+  Tuple new_tuple(num_of_fields);
   for (int i = 0; i < num_of_fields; i++) {
     ASSIGN_OR_RETURN(Field * record_field, record->GetField(out_field_idxs[i]));
     if (record_field == nullptr) {

--- a/komfydb/storage/heap_page.cc
+++ b/komfydb/storage/heap_page.cc
@@ -122,7 +122,7 @@ absl::StatusOr<std::unique_ptr<HeapPage>> HeapPage::Create(
 
   header.insert(header.end(), data.begin(), data.begin() + header_len);
   for (int i = 0; i < n_slots; i++) {
-    Record record(tuple_desc, pid, i);
+    Record record(tuple_desc->Length(), pid, i);
 
     if (!TuplePresent(header, i).value()) {
       data_idx += tuple_desc->GetSize();

--- a/komfydb/storage/heap_page_test.cc
+++ b/komfydb/storage/heap_page_test.cc
@@ -73,10 +73,9 @@ TEST_F(HeapPageTest, Records) {
       continue;
     }
     Record& record = records[rid++];
-    EXPECT_EQ(record.GetTupleDesc(), tuple_desc.get());
     EXPECT_EQ(record.GetId(), RecordId(pid, i));
 
-    Record comp_record(record.GetTupleDesc(), pid, i);
+    Record comp_record(tuple_desc->Length(), pid, i);
     ASSERT_TRUE(
         comp_record.SetField(0, std::make_unique<IntField>(i + 1)).ok());
     ASSERT_TRUE(
@@ -108,8 +107,8 @@ TEST_F(HeapPageTest, AddAndRemoveTuples) {
       HeapPage::Create(pid, tuple_desc.get(), empty_data);
   ASSERT_TRUE(hpage.ok());
 
-  Tuple t[3] = {Tuple(tuple_desc.get()), Tuple(tuple_desc.get()),
-                Tuple(tuple_desc.get())};
+  Tuple t[3] = {Tuple(tuple_desc->Length()), Tuple(tuple_desc->Length()),
+                Tuple(tuple_desc->Length())};
   ASSERT_TRUE(t[0].SetField(0, std::make_unique<IntField>(0)).ok());
   ASSERT_TRUE(t[0].SetField(1, std::make_unique<StringField>("a")).ok());
   ASSERT_TRUE(t[0].SetField(2, std::make_unique<IntField>(1)).ok());

--- a/komfydb/storage/record.cc
+++ b/komfydb/storage/record.cc
@@ -17,6 +17,9 @@ Record::Record(const Record& r) : Tuple(r), rid(r.rid) {}
 
 Record::Record(const Tuple& t, RecordId rid) : Tuple(t), rid(rid) {}
 
+Record::Record(int size, PageId pid, int tuple_no)
+    : Tuple(size), rid(pid, tuple_no) {}
+
 RecordId Record::GetId() {
   return rid;
 }

--- a/komfydb/storage/record.h
+++ b/komfydb/storage/record.h
@@ -33,8 +33,7 @@ class Record : public Tuple {
 
   Record& operator=(const Record& r);
 
-  Record(const TupleDesc* tuple_desc, PageId pid, int tuple_no)
-      : Tuple(tuple_desc), rid(pid, tuple_no) {}
+  Record(int size, PageId pid, int tuple_no);
 
   RecordId GetId();
 


### PR DESCRIPTION
Tuples do not need to know their tuple descriptor:
- Fields "know" their type,
- Tuples do not need to know their fields names.

Moreover, I think that "TupleDesc" is a bad name -- "ColumnDesc" seems more suited to the purpose of this class.